### PR TITLE
Create subdir 'Packages' when creating a new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you would like to provide Red Hat Errata Information to systems not connected
 
 # Log files
 
-All scripts log their STDOUT to */var/log/<SCRIPTNAME>.log*. STDERR is not redirected because I run the scripts via cron and would like to get notifed by email if something was written to STDOUT.
+All scripts log their STDOUT to `/var/log/<SCRIPTNAME>.log`. STDERR is not redirected because I run the scripts via cron and would like to get notifed by email if something was written to STDOUT.
 
 # Links and sources
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The poor man's RHEL mirror
 
-In this repository I have collected some small scripts to set up a local mirror server for Red Hat Repositories. I called it 'poor man's mirror' because it is only capable of providing basic functionallity and could not compete with Red Hat's sattelite server.
+In this repository I have collected some small scripts to set up a local mirror server for Red Hat Repositories. I called it 'poor man's mirror' because it is only capable of providing basic functionallity and could not compete with Red Hat's [Satellite](https://www.redhat.com/en/technologies/management/satellite) server.
 
 You find in each script a short description and comments on how to use it. The following sections give you a short overview, too.
 

--- a/create_yum_repo.sh
+++ b/create_yum_repo.sh
@@ -39,7 +39,7 @@ check()
 
 create_repo()
 {
-mkdir $BASEDIR$REPONAME
+mkdir -p ${BASEDIR}${REPONAME}/Packages
 createrepo --database $BASEDIR$REPONAME 
 REPOID=`echo $REPONAME | tr "[a-z]" "[A-Z]"`
 


### PR DESCRIPTION
The script `create_yum_repo.sh` was modified to create a subdirectory 'Packages' when creating a new repository. I think this new subdirectory helps to keep order in your repo when you put your RPMs in it. And it aligns with the official RHEL repos which come with this subdir, too.